### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/docs/doxygen2rst.py
+++ b/docs/doxygen2rst.py
@@ -12,7 +12,7 @@ MAX_COLUMN = 80
 
 def is_valid_uuid(uuid_string):
     uuid4hex = re.compile('[0-9a-f]{32}\Z', re.I)
-    return uuid4hex.match(uuid_string) != None
+    return uuid4hex.match(uuid_string) is not None
 
 def get_page(refid):
     fields = refid.split("_")
@@ -233,7 +233,7 @@ class DoxyGen2RST(object):
 
     def _build_itemizedlist(self, node):
         retstr = LINE_BREAKER
-        if(node == None):
+        if(node is None):
             return ""
         for item in node:
             if(item.tag != "listitem"):
@@ -300,7 +300,7 @@ class DoxyGen2RST(object):
 
     def get_text(self, node):
         retstr = ""
-        if(node == None):
+        if(node is None):
             return ""
         for para in node:
             if(para.tag != "para"):
@@ -455,13 +455,13 @@ class DoxyGen2RST(object):
         detail_node = member.find("detaileddescription")
         brief_node = member.find("briefdescription")
         detail_txt = ""
-        if(detail_node == None and brief_node == None):
+        if(detail_node is None and brief_node is None):
             return None
 
         if(detail_node is not None):
             detail_txt = detail_node.findtext("para")
 
-        if(not detail_txt and brief_node != None):
+        if(not detail_txt and brief_node is not None):
             detail_txt = brief_node.findtext("para")
             detail_node = brief_node
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:openh264?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:openh264?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
