### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/build/mktargets.py
+++ b/build/mktargets.py
@@ -21,34 +21,34 @@ OUTFILE="targets.mk"
 CPP_SUFFIX=".cpp"
 
 def write_cpp_rule_pattern(f):
-    src = "$(%s_SRCDIR)/%%%s"%(PREFIX, CPP_SUFFIX)
-    dst = "$(%s_SRCDIR)/%%.$(OBJ)"%(PREFIX)
+    src = "$({0!s}_SRCDIR)/%{1!s}".format(PREFIX, CPP_SUFFIX)
+    dst = "$({0!s}_SRCDIR)/%.$(OBJ)".format((PREFIX))
 
-    f.write("%s: %s\n"%(dst, src))
+    f.write("{0!s}: {1!s}\n".format(dst, src))
     f.write('\t$(QUIET_CXX)$(CXX) $(CFLAGS) $(CXXFLAGS) $(INCLUDES) $(' + PREFIX + '_CFLAGS) $(' + PREFIX + '_INCLUDES) -c $(CXX_O) $<\n')
     f.write("\n")
 
 def write_c_rule_pattern(f):
-    src = "$(%s_SRCDIR)/%%.c"%(PREFIX)
-    dst = "$(%s_SRCDIR)/%%.$(OBJ)"%(PREFIX)
+    src = "$({0!s}_SRCDIR)/%.c".format((PREFIX))
+    dst = "$({0!s}_SRCDIR)/%.$(OBJ)".format((PREFIX))
 
-    f.write("%s: %s\n"%(dst, src))
+    f.write("{0!s}: {1!s}\n".format(dst, src))
     f.write('\t$(QUIET_CC)$(CC) $(CFLAGS) $(INCLUDES) $(' + PREFIX + '_CFLAGS) $(' + PREFIX + '_INCLUDES) -c $(CXX_O) $<\n')
     f.write("\n")
 
 def write_asm_rule_pattern(f):
-    src = "$(%s_SRCDIR)/%%.asm"%(PREFIX)
-    dst = "$(%s_SRCDIR)/%%.$(OBJ)"%(PREFIX)
+    src = "$({0!s}_SRCDIR)/%.asm".format((PREFIX))
+    dst = "$({0!s}_SRCDIR)/%.$(OBJ)".format((PREFIX))
 
-    f.write("%s: %s\n"%(dst, src))
+    f.write("{0!s}: {1!s}\n".format(dst, src))
     f.write('\t$(QUIET_ASM)$(ASM) $(ASMFLAGS) $(ASM_INCLUDES) $(' + PREFIX + '_ASMFLAGS) $(' + PREFIX + '_ASM_INCLUDES) -o $@ $<\n')
     f.write("\n")
 
 def write_asm_s_rule_pattern(f):
-    src = "$(%s_SRCDIR)/%%.S"%(PREFIX)
-    dst = "$(%s_SRCDIR)/%%.$(OBJ)"%(PREFIX)
+    src = "$({0!s}_SRCDIR)/%.S".format((PREFIX))
+    dst = "$({0!s}_SRCDIR)/%.$(OBJ)".format((PREFIX))
 
-    f.write("%s: %s\n"%(dst, src))
+    f.write("{0!s}: {1!s}\n".format(dst, src))
     f.write('\t$(QUIET_CCAS)$(CCAS) $(CCASFLAGS) $(ASMFLAGS) $(INCLUDES) $(' + PREFIX + '_CFLAGS) $(' + PREFIX + '_INCLUDES) -c -o $@ $<\n')
     f.write("\n")
 
@@ -100,7 +100,7 @@ OUTFILE = os.path.abspath(OUTFILE)
 try:
     os.chdir(args.directory)
 except OSError as e:
-    sys.stderr.write("Error changing directory to %s\n" % e.filename)
+    sys.stderr.write("Error changing directory to {0!s}\n".format(e.filename))
     sys.exit(1)
 
 (cpp, asm, cfiles, sfiles) = find_sources()
@@ -121,55 +121,55 @@ for file in sfiles:
 
 
 f = open(OUTFILE, "w")
-f.write("%s_SRCDIR=%s\n"%(PREFIX, args.directory))
+f.write("{0!s}_SRCDIR={1!s}\n".format(PREFIX, args.directory))
 
-f.write("%s_CPP_SRCS=\\\n"%(PREFIX))
+f.write("{0!s}_CPP_SRCS=\\\n".format((PREFIX)))
 for c in cpp:
-    f.write("\t$(%s_SRCDIR)/%s\\\n"%(PREFIX, c))
+    f.write("\t$({0!s}_SRCDIR)/{1!s}\\\n".format(PREFIX, c))
 f.write("\n")
-f.write("%s_OBJS += $(%s_CPP_SRCS:%s=.$(OBJ))\n\n"%(PREFIX, PREFIX, CPP_SUFFIX))
+f.write("{0!s}_OBJS += $({1!s}_CPP_SRCS:{2!s}=.$(OBJ))\n\n".format(PREFIX, PREFIX, CPP_SUFFIX))
 
 if len(cfiles) > 0:
-    f.write("%s_C_SRCS=\\\n"%(PREFIX))
+    f.write("{0!s}_C_SRCS=\\\n".format((PREFIX)))
     for cfile in cfiles:
-        f.write("\t$(%s_SRCDIR)/%s\\\n"%(PREFIX, cfile))
+        f.write("\t$({0!s}_SRCDIR)/{1!s}\\\n".format(PREFIX, cfile))
     f.write("\n")
-    f.write("%s_OBJS += $(%s_C_SRCS:.c=.$(OBJ))\n"%(PREFIX, PREFIX))
+    f.write("{0!s}_OBJS += $({1!s}_C_SRCS:.c=.$(OBJ))\n".format(PREFIX, PREFIX))
 
 if len(asm) > 0:
-    f.write("%s_ASM_SRCS=\\\n"%(PREFIX))
+    f.write("{0!s}_ASM_SRCS=\\\n".format((PREFIX)))
     for c in asm:
-        f.write("\t$(%s_SRCDIR)/%s\\\n"%(PREFIX, c))
+        f.write("\t$({0!s}_SRCDIR)/{1!s}\\\n".format(PREFIX, c))
     f.write("\n")
-    f.write("%s_OBJSASM += $(%s_ASM_SRCS:.asm=.$(OBJ))\n"%(PREFIX, PREFIX))
+    f.write("{0!s}_OBJSASM += $({1!s}_ASM_SRCS:.asm=.$(OBJ))\n".format(PREFIX, PREFIX))
     f.write("ifeq ($(ASM_ARCH), x86)\n")
-    f.write("%s_OBJS += $(%s_OBJSASM)\n"%(PREFIX,PREFIX))
+    f.write("{0!s}_OBJS += $({1!s}_OBJSASM)\n".format(PREFIX, PREFIX))
     f.write("endif\n")
-    f.write("OBJS += $(%s_OBJSASM)\n\n"%(PREFIX))
+    f.write("OBJS += $({0!s}_OBJSASM)\n\n".format((PREFIX)))
 
 if len(armfiles) > 0:
-    f.write("%s_ASM_ARM_SRCS=\\\n"%(PREFIX))
+    f.write("{0!s}_ASM_ARM_SRCS=\\\n".format((PREFIX)))
     for c in armfiles:
-        f.write("\t$(%s_SRCDIR)/%s\\\n"%(PREFIX, c))
+        f.write("\t$({0!s}_SRCDIR)/{1!s}\\\n".format(PREFIX, c))
     f.write("\n")
-    f.write("%s_OBJSARM += $(%s_ASM_ARM_SRCS:.S=.$(OBJ))\n"%(PREFIX, PREFIX))
+    f.write("{0!s}_OBJSARM += $({1!s}_ASM_ARM_SRCS:.S=.$(OBJ))\n".format(PREFIX, PREFIX))
     f.write("ifeq ($(ASM_ARCH), arm)\n")
-    f.write("%s_OBJS += $(%s_OBJSARM)\n"%(PREFIX,PREFIX))
+    f.write("{0!s}_OBJS += $({1!s}_OBJSARM)\n".format(PREFIX, PREFIX))
     f.write("endif\n")
-    f.write("OBJS += $(%s_OBJSARM)\n\n"%(PREFIX))
+    f.write("OBJS += $({0!s}_OBJSARM)\n\n".format((PREFIX)))
 
 if len(arm64files) > 0:
-    f.write("%s_ASM_ARM64_SRCS=\\\n"%(PREFIX))
+    f.write("{0!s}_ASM_ARM64_SRCS=\\\n".format((PREFIX)))
     for c in arm64files:
-        f.write("\t$(%s_SRCDIR)/%s\\\n"%(PREFIX, c))
+        f.write("\t$({0!s}_SRCDIR)/{1!s}\\\n".format(PREFIX, c))
     f.write("\n")
-    f.write("%s_OBJSARM64 += $(%s_ASM_ARM64_SRCS:.S=.$(OBJ))\n"%(PREFIX, PREFIX))
+    f.write("{0!s}_OBJSARM64 += $({1!s}_ASM_ARM64_SRCS:.S=.$(OBJ))\n".format(PREFIX, PREFIX))
     f.write("ifeq ($(ASM_ARCH), arm64)\n")
-    f.write("%s_OBJS += $(%s_OBJSARM64)\n"%(PREFIX,PREFIX))
+    f.write("{0!s}_OBJS += $({1!s}_OBJSARM64)\n".format(PREFIX, PREFIX))
     f.write("endif\n")
-    f.write("OBJS += $(%s_OBJSARM64)\n\n"%(PREFIX))
+    f.write("OBJS += $({0!s}_OBJSARM64)\n\n".format((PREFIX)))
 
-f.write("OBJS += $(%s_OBJS)\n\n"%(PREFIX))
+f.write("OBJS += $({0!s}_OBJS)\n\n".format((PREFIX)))
 write_cpp_rule_pattern(f)
 
 if len(cfiles) > 0:
@@ -182,17 +182,17 @@ if len(sfiles) > 0:
     write_asm_s_rule_pattern(f)
 
 if args.library is not None:
-    f.write("$(LIBPREFIX)%s.$(LIBSUFFIX): $(%s_OBJS)\n"%(args.library, PREFIX))
+    f.write("$(LIBPREFIX){0!s}.$(LIBSUFFIX): $({1!s}_OBJS)\n".format(args.library, PREFIX))
     f.write("\t$(QUIET)rm -f $@\n")
     f.write("\t$(QUIET_AR)$(AR) $(AR_OPTS) $+\n")
     f.write("\n")
-    f.write("libraries: $(LIBPREFIX)%s.$(LIBSUFFIX)\n"%args.library)
-    f.write("LIBRARIES += $(LIBPREFIX)%s.$(LIBSUFFIX)\n"%args.library)
+    f.write("libraries: $(LIBPREFIX){0!s}.$(LIBSUFFIX)\n".format(args.library))
+    f.write("LIBRARIES += $(LIBPREFIX){0!s}.$(LIBSUFFIX)\n".format(args.library))
 
 if args.binary is not None:
-    f.write("%s$(EXEEXT): $(%s_OBJS) $(%s_DEPS)\n"%(args.binary, PREFIX, PREFIX))
-    f.write("\t$(QUIET_CXX)$(CXX) $(CXX_LINK_O) $(%s_OBJS) $(%s_LDFLAGS) $(LDFLAGS)\n\n"%(PREFIX, PREFIX))
-    f.write("binaries: %s$(EXEEXT)\n"%args.binary)
-    f.write("BINARIES += %s$(EXEEXT)\n"%args.binary)
+    f.write("{0!s}$(EXEEXT): $({1!s}_OBJS) $({2!s}_DEPS)\n".format(args.binary, PREFIX, PREFIX))
+    f.write("\t$(QUIET_CXX)$(CXX) $(CXX_LINK_O) $({0!s}_OBJS) $({1!s}_LDFLAGS) $(LDFLAGS)\n\n".format(PREFIX, PREFIX))
+    f.write("binaries: {0!s}$(EXEEXT)\n".format(args.binary))
+    f.write("BINARIES += {0!s}$(EXEEXT)\n".format(args.binary))
 
 f.close()

--- a/docs/doxygen2rst.py
+++ b/docs/doxygen2rst.py
@@ -140,7 +140,7 @@ class DoxyGen2RST(object):
             retstr = self._build_uml(m.groups()[1], m.groups()[2])
         elif(m.groups()[0] == "link"):
             link = m.groups()[1] + self.page_ext
-            retstr = ("`%s <%s>`_" % (m.groups()[2], link))
+            retstr = ("`{0!s} <{1!s}>`_".format(m.groups()[2], link))
         else:
             if(m.groups()[0] != "function"):
                 retstr +=  self._build_title(m.groups()[2])
@@ -188,7 +188,7 @@ class DoxyGen2RST(object):
         retstr += target + "_ "
         if target in self.page_references:
             reflink = self.page_references[target]
-            print("Link already added: %s == %s" % (reflink[0], node.attrib["refid"]))
+            print("Link already added: {0!s} == {1!s}".format(reflink[0], node.attrib["refid"]))
             assert(reflink[0] == node.attrib["refid"])
             pass
         else:
@@ -540,8 +540,8 @@ class DoxyGen2RST(object):
         return retstr
 
     def covert_item(self, compound, id, tag):
-        xml_path = os.path.join(self.doxy_output_dir, "%s.xml" % compound)
-        print("covert_item: id=%s, name=%s" % (id, xml_path))
+        xml_path = os.path.join(self.doxy_output_dir, "{0!s}.xml".format(compound))
+        print("covert_item: id={0!s}, name={1!s}".format(id, xml_path))
         obj_root = etree.parse(xml_path).getroot()
         retstr = ""
         compound = obj_root.find("compounddef")
@@ -576,8 +576,8 @@ class DoxyGen2RST(object):
         if(type == "function"):
             file, tag = get_page(ref_id)
             dst_kind = "file"
-        xml_path = os.path.join(self.doxy_output_dir, "%s.xml" % file)
-        print("convert_doxy: type=%s, name=%s" % (type, xml_path))
+        xml_path = os.path.join(self.doxy_output_dir, "{0!s}.xml".format(file))
+        print("convert_doxy: type={0!s}, name={1!s}".format(type, xml_path))
         obj_root = etree.parse(xml_path).getroot()
         compound = obj_root.find("compounddef")
         compound_kind = compound.attrib["kind"]

--- a/module/task_utils.py
+++ b/module/task_utils.py
@@ -37,7 +37,7 @@ def gen_args_type(args, member):
         ret = []
     ret.append("M m")
     for arg in range(0, args):
-        ret.append("A%d a%d"%(arg, arg))
+        ret.append("A{0:d} a{1:d}".format(arg, arg))
     return ", ".join(ret)
 
 def gen_args(args, member):
@@ -47,13 +47,13 @@ def gen_args(args, member):
         ret = []
     ret.append("m")
     for arg in range(0, args):
-        ret.append("a%d"%(arg))
+        ret.append("a{0:d}".format((arg)))
     return ", ".join(ret)
 
 def gen_args_(args):
     ret = []
     for arg in range(0, args):
-        ret.append("a%d_"%(arg))
+        ret.append("a{0:d}_".format((arg)))
     return ", ".join(ret)
 
 def gen_init(args, r = False, member = False):
@@ -67,7 +67,7 @@ def gen_init(args, r = False, member = False):
         ret.append("r_ (r)")
 
     for arg in range(0, args):
-        ret.append("a%d_ (a%d)"%(arg, arg))
+        ret.append("a{0:d}_ (a{1:d})".format(arg, arg))
     return ", ".join(ret)
 
 def gen_typenames(args, member):
@@ -78,7 +78,7 @@ def gen_typenames(args, member):
     ret.append("typename M")
 
     for arg in range(0, args):
-        ret.append("typename A%d"%(arg))
+        ret.append("typename A{0:d}".format((arg)))
     return ", ".join(ret)
 
 def gen_types(args, member):
@@ -88,29 +88,29 @@ def gen_types(args, member):
         ret = []
     ret.append("M")
     for arg in range(0, args):
-        ret.append("A%d"%(arg))
+        ret.append("A{0:d}".format((arg)))
     return ", ".join(ret)
 
 
 def generate_class_template(args, ret = False, member = True):
-    print "// %d arguments --"%args
+    print "// {0:d} arguments --".format(args)
     if member:
         nm = "m"
     else:
         nm = "nm"
 
     if not ret:
-        print "template<"+ gen_typenames(args, member) + "> class gmp_args_%s_%d : public gmp_args_base {"%(nm, args)
+        print "template<"+ gen_typenames(args, member) + "> class gmp_args_{0!s}_{1:d} : public gmp_args_base {{".format(nm, args)
     else:
-        print "template<"+ gen_typenames(args, member) + ", typename R> class gmp_args_%s_%d_ret : public gmp_args_base {"%(nm, args)
+        print "template<"+ gen_typenames(args, member) + ", typename R> class gmp_args_{0!s}_{1:d}_ret : public gmp_args_base {{".format(nm, args)
 
     print " public:"
 
     if not ret:
-        print "  gmp_args_%s_%d ("%(nm, args) + gen_args_type(args, member) + ") :"
+        print "  gmp_args_{0!s}_{1:d} (".format(nm, args) + gen_args_type(args, member) + ") :"
         print "    " + gen_init(args, False, member) + "  {}"
     else:
-        print "  gmp_args_%s_%d_ret ("%(nm, args) + gen_args_type(args, member) + ", R* r) :"
+        print "  gmp_args_{0!s}_{1:d}_ret (".format(nm, args) + gen_args_type(args, member) + ", R* r) :"
         print "    " + gen_init(args, True, member) + "  {}"
         print "  virtual bool returns_value() const {\n    return true;\n  }"
     print
@@ -132,7 +132,7 @@ def generate_class_template(args, ret = False, member = True):
     if ret:
         print "  R* r_;"
     for arg in range(0, args):
-        print "  A%d a%d_;"%(arg, arg)
+        print "  A{0:d} a{1:d}_;".format(arg, arg)
     print "};"
     print
     print
@@ -146,18 +146,18 @@ def generate_function_template(args, member):
         nm = "nm"
         NM = "NM";
 
-    print "// %d arguments --"%args
+    print "// {0:d} arguments --".format(args)
     print "template<" + gen_typenames(args, member) + ">"
-    print "gmp_args_%s_%d<"%(nm, args) + gen_types(args, member) + ">* WrapTask%s ("%NM + gen_args_type(args, member) + ") {"
-    print "  return new gmp_args_%s_%d<"%(nm, args) + gen_types(args, member) + ">"
+    print "gmp_args_{0!s}_{1:d}<".format(nm, args) + gen_types(args, member) + ">* WrapTask{0!s} (".format(NM) + gen_args_type(args, member) + ") {"
+    print "  return new gmp_args_{0!s}_{1:d}<".format(nm, args) + gen_types(args, member) + ">"
     print "    (" + gen_args(args, member) + ");"
     print "}"
     print
     if member:
         print "template<" + gen_typenames(args, member) + ">"
         print "GMPTask*"
-        print "WrapTaskRefCounted%s ("%NM + gen_args_type(args, member) + ") {"
-        print "  GMPTask *t = WrapTask%s ("%NM + gen_args(args, member) + ");"
+        print "WrapTaskRefCounted{0!s} (".format(NM) + gen_args_type(args, member) + ") {"
+        print "  GMPTask *t = WrapTask{0!s} (".format(NM) + gen_args(args, member) + ");"
         print "  return new RefCountTaskWrapper(t, o);"
         print "}"
         print
@@ -169,10 +169,10 @@ def generate_function_template_ret(args, member):
     else:
         nm = "nm"
         NM = "NM";
-    print "// %d arguments --"%args
+    print "// {0:d} arguments --".format(args)
     print "template<" + gen_typenames(args, member) + ", typename R>"
-    print "gmp_args_%s_%d_ret<"%(nm, args) + gen_types(args, member) + ", R>* WrapTask%sRet ("%NM + gen_args_type(args, member) + ", R* r) {"
-    print "  return new gmp_args_%s_%d_ret<"%(nm, args) + gen_types(args, member) + ", R>"
+    print "gmp_args_{0!s}_{1:d}_ret<".format(nm, args) + gen_types(args, member) + ", R>* WrapTask{0!s}Ret (".format(NM) + gen_args_type(args, member) + ", R* r) {"
+    print "  return new gmp_args_{0!s}_{1:d}_ret<".format(nm, args) + gen_types(args, member) + ", R>"
     print "    (" + gen_args(args, member) + ", r);"
     print "}"
     print


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:openh264?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:openh264?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
